### PR TITLE
Fix Heroku deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "babel": "^6.23.0",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-2": "^6.24.1",
+    "babel-register": "^6.26.0",
     "bluebird": "^3.5.0",
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
@@ -23,12 +29,6 @@
     "node-fetch": "^1.7.2"
   },
   "devDependencies": {
-    "babel": "^6.23.0",
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-2": "^6.24.1",
-    "babel-register": "^6.26.0",
     "nodemon": "^1.11.0",
     "request": "^2.81.0",
     "tape": "^4.7.0"


### PR DESCRIPTION
- [X] Move `babel` package from `devDependencies` to `dependencies` in `package.json`

Closes #9